### PR TITLE
Windows support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,8 +114,6 @@ fn compile_build_crate(build_dir: &BuildDir, cargo: &str, temp: &str, path: &str
         .output()
         .expect("failed to compile build-script crate");
 
-    println!("{:#?}", res);
-
     assert!(
         res.status.success(),
         "Failed to run compile build crate at {} with {:#?}",


### PR DESCRIPTION
This PR makes the following changes:

- BuildDir now doesn't depends on /dev/urandom, instead it uses SystemTime.
- cp_r was rewritten to handle the copy itself instead of calling cp.
- TEMP & SYSTEMROOT are now exported in compile_build_create

Please keep in mind that no_std linking is broken on Windows with MSVC and that "bin-crate" will not link as a result in this environment. (windows-gnu variant however work correctly)